### PR TITLE
make sure top-level widgets can be found by object name

### DIFF
--- a/camelot/core/qt.py
+++ b/camelot/core/qt.py
@@ -140,6 +140,7 @@ if qt_api in ('', 'PyQt5'):
         QtQuickWidgets = DelayedModule('QtQuickWidgets')
         is_deleted = sip.isdeleted
         delete = sip.delete
+        transferto = sip.transferto
     except ImportError:
         LOGGER.warn('Could not load PyQt5')
         qt_api = ''

--- a/camelot/view/action_steps/form_view.py
+++ b/camelot/view/action_steps/form_view.py
@@ -71,6 +71,7 @@ class OpenFormView( ActionStep ):
     """
 
     def __init__( self, objects, admin ):
+        self.admin_name = admin.get_name()
         self.objects = objects
         self.admin = admin
         self.row = 0
@@ -130,6 +131,9 @@ class OpenFormView( ActionStep ):
         formview = self.render(gui_context)
         if formview is not None:
             if self.top_level == True:
+                formview.setObjectName('form.{}.{}'.format(
+                    self.admin_name, id(formview)
+                ))
                 show_top_level(formview, window, self.admin.form_state)
             else:
                 gui_context.workspace.set_view(formview)

--- a/camelot/view/action_steps/item_view.py
+++ b/camelot/view/action_steps/item_view.py
@@ -154,6 +154,7 @@ class OpenTableView( UpdateTableView ):
     
     def __init__( self, admin, value ):
         super(OpenTableView, self).__init__(admin, value)
+        self.admin_name = admin.get_name()
         self.subclasses = admin.get_subclass_tree()
         self.new_tab = False
 
@@ -172,6 +173,9 @@ class OpenTableView( UpdateTableView ):
             else:
                 gui_context.workspace.set_view(table_view)
         else:
+            table_view.setObjectName('table.{}.{}'.format(
+                self.admin_name, id(table_view)
+            ))
             show_top_level(table_view, None)
         table_view.change_title(self.title)
         table_view.setFocus(Qt.PopupFocusReason)

--- a/camelot/view/controls/editors/one2manyeditor.py
+++ b/camelot/view/controls/editors/one2manyeditor.py
@@ -31,7 +31,7 @@ import logging
 
 from camelot.admin.action.list_action import ListActionGuiContext
 from camelot.view.model_thread import post
-from camelot.view import register
+from camelot.view.proxy.collection_proxy import CollectionProxy
 from ....core.qt import Qt, QtCore, QtWidgets, variant_to_py
 from ....core.item_model import ListModelProxy
 from ..action_widget import ActionAction
@@ -49,9 +49,6 @@ class One2ManyEditor(CustomEditor, WideEditor):
     :param create_inline: if False, then a new entity will be created within a
     new window, if True, it will be created inline
 
-    :param proxy: the proxy class to use to present the data in the list or
-        the query to the table view
-
     :param column_width: the width of the editor in number of characters
 
     :param rows: minimum number of rows visible
@@ -67,7 +64,6 @@ class One2ManyEditor(CustomEditor, WideEditor):
                  direction='onetomany',
                  field_name='onetomany',
                  column_width=None,
-                 proxy=None,
                  columns=[],
                  toolbar_actions=[],
                  rows=5,
@@ -80,7 +76,6 @@ class One2ManyEditor(CustomEditor, WideEditor):
         # Setup table
         #
         from camelot.view.controls.tableview import AdminTableWidget
-        from camelot.view.proxy.collection_proxy import CollectionProxy
         # parent set by layout manager
         table = AdminTableWidget(admin, self)
         table.setObjectName('table')
@@ -91,9 +86,9 @@ class One2ManyEditor(CustomEditor, WideEditor):
         table.verticalHeader().sectionClicked.connect(
             self.trigger_list_action
         )
-        model = (proxy or CollectionProxy)(admin)
+        model = CollectionProxy(admin)
+        model.setParent(self)
         table.setModel(model)
-        register.register(model, table)
         self.admin = admin
         self.direction = direction
         self.create_inline = create_inline

--- a/camelot/view/controls/formview.py
+++ b/camelot/view/controls/formview.py
@@ -41,7 +41,6 @@ from camelot.admin.action.form_action import FormActionGuiContext
 from camelot.view.proxy.collection_proxy import VerboseIdentifierRole
 from camelot.view.controls.view import AbstractView
 from camelot.view.controls.busy_widget import BusyWidget
-from camelot.view import register
 from .delegates.delegatemanager import DelegateManager
 
 class FormEditors(QtCore.QObject):
@@ -140,9 +139,9 @@ class FormWidget(QtWidgets.QWidget):
             model.modelReset.connect(self._layout_changed)
             model.rowsInserted.connect(self._layout_changed)
             model.rowsRemoved.connect(self._layout_changed)
+            model.setParent(self)
             if widget_mapper is not None:
-                widget_mapper.setModel( model )
-                register.register( model, widget_mapper )
+                widget_mapper.setModel(model)
 
     def get_model(self):
         widget_mapper = self.findChild(QtWidgets.QDataWidgetMapper, 'widget_mapper')

--- a/camelot/view/controls/tableview.py
+++ b/camelot/view/controls/tableview.py
@@ -39,7 +39,6 @@ from camelot.core.utils import ugettext as _
 from camelot.view.art import FontIcon
 from camelot.view.controls.view import AbstractView
 from camelot.view.model_thread import object_thread
-from camelot.view import register
 from ...core.qt import QtCore, QtGui, QtModel, QtWidgets, Qt, variant_to_py
 from ..proxy.collection_proxy import CollectionProxy
 from .actionsbox import ActionsBox
@@ -249,7 +248,7 @@ class TableWidget(QtWidgets.QTableView):
         # Editor, closed. it should be safe to change the model
         #
         QtWidgets.QTableView.setModel(self, model)
-        register.register(model, self)
+        model.setParent(self)
         # assign selection model to local variable to keep it alive during
         # method call, or PySide segfaults
         selection_model = self.selectionModel()

--- a/camelot/view/workspace.py
+++ b/camelot/view/workspace.py
@@ -35,7 +35,7 @@ import logging
 logger = logging.getLogger('camelot.view.workspace')
 
 from ..core import constants
-from ..core.qt import QtCore, QtGui, QtWidgets
+from ..core.qt import QtCore, QtGui, QtWidgets, transferto
 from camelot.admin.action import ApplicationActionGuiContext
 from camelot.view.model_thread import object_thread
 
@@ -226,26 +226,31 @@ def show_top_level(view, parent, state=None):
         window will be placed.
     :param state: the state of the form, 'maximized', or 'left' or 'right', ...
      """
-    from camelot.view.register import register
     #
-    # Register the view with reference to itself.  This will keep
-    # the Python object alive as long as the Qt object is not
-    # destroyed.  Hence Python will not trigger the deletion of the
-    # view as long as the window is not closed
+    # assert the view has an objectname, so it can be retrieved later
+    # by this object name, since a top level view might have no references
+    # from other objects.
     #
-    register( view, view )
+    assert len(view.objectName())
     #
-    # asset the parent is None to avoid the window being destructed
+    # assert the parent is None to avoid the window being destructed
     # once the parent gets destructed, do not set the parent itself here,
     # nor the window flags, as this might cause windows to hide themselves
     # again after being shown in Qt5
     #
     assert view.parent() is None
     #
+    # Register the view with reference to itself.  This will keep
+    # the Python object alive as long as the Qt object is not
+    # destroyed.  Hence Python will not trigger the deletion of the
+    # view as long as the window is not closed
+    #
+    transferto(view, view)
+    #
     # Make the window title blank to prevent the something
     # like main.py or pythonw being displayed
     #
-    view.setWindowTitle( u' ' )
+    view.setWindowTitle(' ')
     view.title_changed_signal.connect( view.setWindowTitle )
     view.icon_changed_signal.connect( view.setWindowIcon )
     view.setAttribute(QtCore.Qt.WA_DeleteOnClose)


### PR DESCRIPTION
This is a first step towards a react pattern.  To allow the top level render method to retrieve the top level widgets on which to render received messages.  Also the use of the global python register is phased out, to allow the react render method to work both from python as from C++.