### PR TITLE
register actions rendered on a view 

### DIFF
--- a/camelot/admin/action/application_action.py
+++ b/camelot/admin/action/application_action.py
@@ -58,6 +58,10 @@ class ApplicationActionModelContext( ModelContext ):
    
         the application admin.
 
+    .. attribute:: actions
+
+        the actions in the same context
+
     .. attribute:: session
 
         the active session
@@ -66,6 +70,7 @@ class ApplicationActionModelContext( ModelContext ):
     def __init__( self ):
         super( ApplicationActionModelContext, self ).__init__()
         self.admin = None
+        self.actions = []
 
     # Cannot set session in constructor because constructor is called
     # inside the GUI thread
@@ -86,6 +91,12 @@ class ApplicationActionGuiContext( GuiContext ):
     .. attribute:: admin_route
     
         the route to the reference of the view on the server
+
+    .. attribute:: action_routes
+
+        a list with routes to actions in the current context, mapping the
+        route to the action to the route to the rendered action displaying the
+        action state.
     """
     
     model_context = ApplicationActionModelContext
@@ -94,6 +105,7 @@ class ApplicationActionGuiContext( GuiContext ):
         super( ApplicationActionGuiContext, self ).__init__()
         self.workspace = None
         self.admin_route = None
+        self.action_routes = {}
     
     def get_progress_dialog(self):
         if self.workspace is not None and not is_deleted(self.workspace):
@@ -120,12 +132,15 @@ class ApplicationActionGuiContext( GuiContext ):
         # to keep the FieldAction working
         context = super( ApplicationActionGuiContext, self ).create_model_context()
         context.admin = AdminRoute.admin_for(self.admin_route) if self.admin_route is not None else None
+        # todo : action routes should be translated to actions here
+        context.actions = list(self.action_routes.keys())
         return context
         
     def copy(self, base_class=None):
         new_context = super( ApplicationActionGuiContext, self ).copy(base_class)
         new_context.workspace = self.workspace
         new_context.admin_route = self.admin_route
+        new_context.action_routes = dict(self.action_routes)
         return new_context
         
 class SelectProfile( Action ):

--- a/camelot/admin/action/base.py
+++ b/camelot/admin/action/base.py
@@ -217,7 +217,11 @@ the default mode.
         action = QtWidgets.QAction( parent )
         action.setData( self.name )
         action.setText( six.text_type(self.verbose_name) )
-        action.setIconVisibleInMenu( False )
+        if self.icon is None:
+            action.setIconVisibleInMenu(False)
+        else:
+            action.setIcon(self.icon.getQIcon())
+            action.setIconVisibleInMenu(True)
         return action
         
 class ActionStep( object ):

--- a/camelot/view/action_steps/__init__.py
+++ b/camelot/view/action_steps/__init__.py
@@ -29,7 +29,7 @@
 
 from .application import (
     MainWindow, InstallTranslator, Exit, RemoveTranslators, NavigationPanel,
-    MainMenu,
+    MainMenu, UpdateActionsState,
 )
 from .change_object import ChangeField, ChangeObject, ChangeObjects
 from .form_view import (OpenFormView, ToFirstForm, ToLastForm, ToNextForm,
@@ -91,6 +91,7 @@ __all__ = [
     ToLastForm.__name__,
     ToNextForm.__name__,
     ToPreviousForm.__name__,
+    UpdateActionsState.__name__,
     UpdateEditor.__name__,
     UpdateObjects.__name__,
     UpdateProgress.__name__,

--- a/camelot/view/action_steps/application.py
+++ b/camelot/view/action_steps/application.py
@@ -27,8 +27,13 @@
 #
 #  ============================================================================
 
+import logging
+
 from ...admin.action.base import ActionStep
 from ...core.qt import QtCore, Qt, QtWidgets
+
+LOGGER = logging.getLogger(__name__)
+
 
 class Exit( ActionStep ):
     """
@@ -185,3 +190,27 @@ class RemoveTranslators(ActionStep):
         for active_translator in app.findChildren(QtCore.QTranslator):
             app.removeTranslator(active_translator)
 
+
+class UpdateActionsState(ActionStep):
+    """
+    Update the the state of a list of `Actions`
+
+    :param action_states: a `dict` mapping the action_routes to their
+        updated state.
+
+    """
+
+    def __init__(self, actions_state):
+        self.actions_state = actions_state
+
+    def gui_run(self, gui_context):
+        for action_route, action_state in self.actions_state.items():
+            rendered_action_route = gui_context.action_routes.get(action_route)
+            if rendered_action_route is None:
+                LOGGER.warn('Cannot update rendered action, rendered_action_route is unknown')
+                continue
+            qobject = gui_context.view.findChild(QtCore.QObject, rendered_action_route)
+            if qobject is None:
+                LOGGER.warn('Cannot update rendered action, QObject child {} not found'.format(rendered_action_route))
+                continue
+            qobject.set_state(action_state)

--- a/camelot/view/controls/action_widget.py
+++ b/camelot/view/controls/action_widget.py
@@ -108,12 +108,16 @@ class AbstractActionWidget( object ):
         if state.modes:
             # self is not always a QWidget, so QMenu is created without
             # parent
-            menu = QtWidgets.QMenu()
+            menu = self.menu()
+            if menu is None:
+                menu = QtWidgets.QMenu(parent=self)
+                # setMenu does not transfer ownership
+                self.setMenu(menu)
+            menu.clear()
             for mode in state.modes:
                 mode_action = mode.render(menu)
                 mode_action.triggered.connect(self.action_triggered)
                 menu.addAction(mode_action)
-            self.setMenu( menu )
 
     # not named triggered to avoid confusion with standard Qt slot
     def action_triggered_by(self, sender):

--- a/test/test_action.py
+++ b/test/test_action.py
@@ -498,6 +498,8 @@ class ListActionsCase(
         self.assertTrue(len(state.modes))
         mode_names = set(m.name for m in state.modes)
         self.assertIn('first_name', mode_names)
+        self.assertNotIn('note', mode_names)
+        set_filters.gui_run(self.gui_context)
         #steps = self.gui_run(set_filters, self.gui_context)
         #for step in steps:
             #if isinstance(step, action_steps.ChangeField):


### PR DESCRIPTION
Bij gebrek aan het reeds bestaan van een 'action route' w het action object zelf als route gebruikt.

Di in feite een initiele try om de states van actions te gaan updaten vanuit de model_run,
zodat de 'speciale' afhandeling van de action states weg kan, en kan w afgehandeld in de
model run.