### PR TITLE
Do not redefine signals on subclass.

### DIFF
--- a/camelot/view/controls/editors/choiceseditor.py
+++ b/camelot/view/controls/editors/choiceseditor.py
@@ -44,9 +44,6 @@ class ChoicesEditor(CustomEditor):
     """A ComboBox aka Drop Down box that can be assigned a list of
     keys and values"""
 
-    editingFinished = QtCore.qt_signal()
-    valueChanged = QtCore.qt_signal()
-
     def __init__( self,
                   parent = None,
                   nullable = True,


### PR DESCRIPTION
Qt6 without QT_NO_DEBUG gave these warnings:

QMetaObject::indexOfSignal: signal valueChanged() from CustomEditor redefined in ChoicesEditor