### PR TITLE
Make UpdateTableView.list_actions serializable

### DIFF
--- a/camelot/admin/action/application_action.py
+++ b/camelot/admin/action/application_action.py
@@ -277,6 +277,8 @@ class SelectProfile( Action ):
 class EntityAction( Action ):
     """Generic ApplicationAction that acts upon an Entity class"""
 
+    name = 'entity_action'
+
     def __init__( self, 
                   entity_admin ):
         """

--- a/camelot/admin/action/field_action.py
+++ b/camelot/admin/action/field_action.py
@@ -110,6 +110,7 @@ class FieldAction(Action):
     """Action class that renders itself as a toolbutton, small enough to
     fit in an editor"""
 
+    name = 'field_action'
     render_hint = RenderHint.TOOL_BUTTON
 
 

--- a/camelot/admin/action/list_action.py
+++ b/camelot/admin/action/list_action.py
@@ -233,6 +233,8 @@ class ListContextAction( Action ):
     """An base class for actions that should only be enabled if the
     gui_context is a :class:`ListActionModelContext`
     """
+
+    name = 'list_context_action'
     
     def get_state( self, model_context ):
         state = super( ListContextAction, self ).get_state( model_context )
@@ -262,6 +264,7 @@ class EditAction( ListContextAction ):
     to be non-editable using __facade_args__ = { 'editable': False }.
     """
 
+    name = 'edit_action'
     render_hint = RenderHint.TOOL_BUTTON
 
     def get_state( self, model_context ):
@@ -321,7 +324,7 @@ class OpenFormView( ListContextAction ):
     # verbose name is set to None to avoid displaying it in the vertical
     # header of the table view
     verbose_name = None
-    name = 'open'
+    name = 'open_form_view'
 
     def model_run(self, model_context):
         from camelot.view import action_steps

--- a/camelot/admin/action/list_filter.py
+++ b/camelot/admin/action/list_filter.py
@@ -57,6 +57,8 @@ class All(object):
 class Filter(Action):
     """Base class for filters"""
 
+    name = 'filter'
+
     def __init__(self, attribute, default=All, verbose_name=None):
         """
         :param attribute: the attribute on which to filter, this attribute
@@ -169,6 +171,7 @@ class GroupBoxFilter(Filter):
     """Filter where the items are displayed in a QGroupBox"""
 
     render_hint = RenderHint.GROUP_BOX
+    name = 'group_box_filter'
 
     def __init__(self, attribute, default=All, verbose_name=None, exclusive=True):
         super(GroupBoxFilter, self).__init__(attribute, default, verbose_name)
@@ -179,6 +182,7 @@ class ComboBoxFilter(Filter):
     """Filter where the items are displayed in a QComboBox"""
 
     render_hint = RenderHint.COMBO_BOX
+    name = 'combo_box_filter'
 
 class AbstractSearchStrategy(object):
     """
@@ -388,6 +392,7 @@ class VirtualAddressSearch(FieldSearch):
 class SearchFilter(Action, AbstractModelFilter):
 
     render_hint = RenderHint.SEARCH_BUTTON
+    name = 'search_filter'
 
     #shortcut = QtWidgets.QShortcut(QtGui.QKeySequence(QtGui.QKeySequence.Find),
                                #self)

--- a/camelot/admin/object_admin.py
+++ b/camelot/admin/object_admin.py
@@ -415,7 +415,7 @@ be specified using the verbose_name attribute.
                app_admin.get_related_toolbar_actions( toolbar_area, direction )
 
     def get_list_actions(self):
-        return self.list_actions
+        return [(AdminRoute._register_list_action_route(self._admin_route, action), action.render_hint) for action in self.list_actions]
 
     def get_list_action(self) -> Route:
         """Get the route for the action that should be triggered when an object is selected
@@ -985,3 +985,6 @@ be specified using the verbose_name attribute.
         new_entity_instance = entity_instance.__class__()
         return new_entity_instance
 
+    def is_editable(self):
+        """Default implementation always returns True"""
+        return True

--- a/camelot/model/i18n.py
+++ b/camelot/model/i18n.py
@@ -54,6 +54,7 @@ logger = logging.getLogger( 'camelot.model.i18n' )
 class ExportAsPO( Action ):
 
     verbose_name = _('PO Export')
+    name = 'export_as_po'
     icon = Icon('save') # 'tango/16x16/actions/document-save.png'
 
     def model_run( self, model_context ):

--- a/camelot/model/type_and_status.py
+++ b/camelot/model/type_and_status.py
@@ -386,6 +386,8 @@ class ChangeStatus( Action ):
     this might slow down list views too much.
     """
 
+    name = 'change_status'
+
     def __init__( self, new_status, verbose_name = None ):
         self.verbose_name = verbose_name or _(new_status)
         self.new_status = new_status

--- a/camelot/view/action_steps/item_view.py
+++ b/camelot/view/action_steps/item_view.py
@@ -114,8 +114,7 @@ class UpdateTableView( ActionStep ):
         self.search_text = None
         self.title = admin.get_verbose_name_plural()
         self.filters = admin.get_filters()
-        #self.actions = [(AdminRoute._register_list_action_route(self.admin_route, action), action.render_hint) for action in admin.get_list_actions()]
-        self.list_actions = admin.get_list_actions()
+        self.actions = admin.get_list_actions()
         self.columns = admin.get_columns()
         self.left_toolbar_actions = admin.get_list_toolbar_actions(Qt.LeftToolBarArea)
         self.right_toolbar_actions = admin.get_list_toolbar_actions(Qt.RightToolBarArea)
@@ -134,8 +133,7 @@ class UpdateTableView( ActionStep ):
         # the value is set
         table_view.set_filters(self.filters)
         table_view.set_value(self.proxy_route)
-        #table_view.set_list_actions([AdminRoute.action_for(action[0]) for action in self.actions])
-        table_view.set_list_actions(self.list_actions)
+        table_view.set_list_actions([AdminRoute.action_for(action[0]) for action in self.actions if action[1] == RenderHint.PUSH_BUTTON])
         table_view.list_action = AdminRoute.action_for(self.list_action)
         table_view.set_toolbar_actions(
             Qt.LeftToolBarArea, self.left_toolbar_actions

--- a/camelot_example/importer.py
+++ b/camelot_example/importer.py
@@ -34,6 +34,7 @@ from camelot.view.art import FontIcon
 
 class ImportCovers( Action ):
     verbose_name = _('Import cover images')
+    name = 'import_covers'
     icon = FontIcon('image')
     
 # begin select files


### PR DESCRIPTION
Testen zijjn aan het draaien (gisteren was er nog 1 test die faalde en die zou nu ook in orde zou moeten zijn).

Ik heb de functie AdminRoute._validate_action_name() toegevoegd om het debuggen van action names te vergemakkelijken:
Er waren soms afgeleide action classes die zich registreerde met de naam van hun base class. Wanneer vervolgens de base class geregistreerd werd, was het niet eenvoudig om te achterhalen waarom die naam reeds in gebruik was. 