### PR TITLE
VFIN-1622: Allow serialization of custom Serializable classes

### DIFF
--- a/camelot/core/serializable.py
+++ b/camelot/core/serializable.py
@@ -88,6 +88,8 @@ class DataclassSerializable(Serializable):
     def _asdict_inner(cls, obj):
         if dataclasses._is_dataclass_instance(obj):
             return cls.serialize_fields(obj)
+        elif isinstance(obj, Serializable):
+            return obj._to_dict()
         elif isinstance(obj, (list, tuple)):
             return type(obj)(cls._asdict_inner(v) for v in obj)
         elif isinstance(obj, dict):


### PR DESCRIPTION
… that are not DataclassSerializable. Required for DocumentList since this class derives from list

(zie vfinance PR voor context)