### PR TITLE
VFIN-1826 Expanded NamingContext and ConstantNamingContext

### DIFF
--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -208,7 +208,7 @@ class AbstractNamingContext(object):
         name = self.get_composite_name(name)
         return (*self._name, *name)
 
-    def bind(self, name: Name, obj: object, immutable: False) -> CompositeName:
+    def bind(self, name: Name, obj: object, immutable=False) -> CompositeName:
         """
         Creates a binding of a name and an object in the naming context.
 
@@ -362,7 +362,7 @@ class NamingContext(AbstractNamingContext):
             NameNotFoundException NamingException.Message.name_not_found: if no binding was found for the supplied name.
             AlreadyBoundException NamingException.Message.already_bound : An object is already bound under the supplied name.
         """
-        return self._add_binding(name, obj, False, BindingType.named_object)
+        return self._add_binding(name, obj, False, BindingType.named_object, immutable)
 
     @AbstractNamingContext.check_bounded
     def rebind(self, name: Name, obj: object) -> CompositeName:
@@ -412,7 +412,7 @@ class NamingContext(AbstractNamingContext):
         """
         if not isinstance(context, AbstractNamingContext):
             raise NamingException(NamingException.Message.context_expected, context)
-        return self._add_binding(name, context, False, BindingType.named_context)
+        return self._add_binding(name, context, False, BindingType.named_context, immutable)
 
     @AbstractNamingContext.check_bounded
     def rebind_context(self, name: Name, context: AbstractNamingContext) -> CompositeName:
@@ -590,7 +590,7 @@ class NamingContext(AbstractNamingContext):
                 raise NameNotFoundException(name[0], binding_type)
             obj, immutable = self._bindings[binding_type][name[0]]
             if immutable:
-                raise ImmutableBindingException(binding_type, name)
+                raise ImmutableBindingException(binding_type, name[0])
             self._bindings[binding_type].pop(name[0])
             if binding_type == BindingType.named_context:
                 obj._name = None

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -3,6 +3,7 @@ Server side register for objects whose reference is send to the client.
 Inspired by the Corba/Java NamingContext.
 """
 from __future__ import annotations
+from decimal import Decimal
 
 import functools
 import logging
@@ -581,7 +582,7 @@ class ConstantNamingContext(AbstractNamingContext):
 
     def __init__(self, constant_type):
         super().__init__()
-        assert constant_type in (int, str, bool, float)
+        assert constant_type in (int, str, bool, float, Decimal)
         self.constant_type = constant_type
 
     def resolve(self, name: str) -> object:
@@ -606,5 +607,5 @@ class ConstantNamingContext(AbstractNamingContext):
 
 # Bind ConstantNamingContext to the initial naming context for each supported 'primitive' python type.
 constants_naming_context = initial_naming_context.bind_new_context('constants')
-for constant_type in (int, str, bool): # Do not support floats, as vFinance uses Decimals throughout
-    constants_naming_context.bind_context(constant_type.__name__, ConstantNamingContext(constant_type))
+for constant_type in (int, str, bool, Decimal): # Do not support floats, as vFinance uses Decimals throughout
+    constants_naming_context.bind_context(constant_type.__name__.lower(), ConstantNamingContext(constant_type))

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -48,6 +48,7 @@ class NamingException(Exception):
 
         invalid_name = 'The given name is invalid'
         # Invalid name reasons
+        invalid_name_type = 'name should an atomic name or a composite name'
         invalid_atomic_name = 'atomic name should be a string'
         invalid_atomic_name_length = 'atomic name should contain at least 1 character'
         invalid_composite_name = 'composite name should be a tuple'
@@ -166,7 +167,7 @@ class AbstractNamingContext(object):
             cls.validate_composite_name(name)
             cls.validate_atomic_name(name[0])
             return name
-        raise NamingException(NamingException.Message.invalid_name)
+        raise NamingException(NamingException.Message.invalid_name, reason=NamingException.Message.invalid_name_type)
 
     def check_bounded(func):
         # Validation decorator that checks and raises when this context is unbound.

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -754,9 +754,9 @@ class InitialNamingContext(NamingContext, metaclass=Singleton):
         constants = self.bind_new_context('constants', immutable=True)
         for constant_type in (str, int, Decimal): # Do not support floats, as vFinance uses Decimals throughout
             constants.bind_context(constant_type.__name__.lower(), ConstantNamingContext(constant_type), immutable=True)
-        constants.bind('None', None, immutable=True)
-        constants.bind('True', True, immutable=True)
-        constants.bind('False', False, immutable=True)
+        constants.bind('null', None, immutable=True)
+        constants.bind('true', True, immutable=True)
+        constants.bind('false', False, immutable=True)
 
     def new_context(self) -> NamingContext:
         """

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -118,7 +118,7 @@ class AbstractNamingContext(object):
         self._name = None
 
     @classmethod
-    def validate_atomic_name(cls, name: str) -> typing.Optional[NamingException.Message]:
+    def validate_atomic_name(cls, name: str):
         """
         Validate an atomic name for this naming context.
         This method will be used to validate names used within this context,

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -585,6 +585,7 @@ class ConstantNamingContext(AbstractNamingContext):
         assert constant_type in (int, str, bool, float, Decimal)
         self.constant_type = constant_type
 
+    @AbstractNamingContext.check_bounded
     def resolve(self, name: str) -> object:
         """
         Resolve a name in this ConstantNamingContext and return the bound object.

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -25,11 +25,15 @@ class BindingType(Enum):
 
 class NamingException(Exception):
 
-    def __init__(self, message, *args, **kwargs):
+    def __init__(self, message, *args, reason=None, **kwargs):
         assert isinstance(message, self.Message)
-        self.message = message
+        assert reason is None or isinstance(reason, self.Message)
         self.message_text = message.value.format(*args, **kwargs)
+        if reason is not None:
+            self.message_text = self.message_text + ': ' + reason
         super().__init__(self.message_text)
+        self.message = message
+        self.reason = reason
 
     class Message(Enum):
 

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -421,8 +421,8 @@ class NamingContext(AbstractNamingContext):
         if binding_type not in BindingType:
             raise NamingException(NamingException.Message.invalid_binding_type)
         if len(name) == 1:
-            bound_obj = self._bindings[binding_type].get(name[0])
-            if not rebind and bound_obj is not None:
+            # If binding, check if their exists one already
+            if not rebind and name[0] in self._bindings[binding_type]:
                 raise AlreadyBoundException(name[0], binding_type)
 
             # Add the object to the registry for the given binding_type.
@@ -567,10 +567,9 @@ class NamingContext(AbstractNamingContext):
         if binding_type not in BindingType:
             raise NamingException(NamingException.Message.invalid_binding_type)
         if len(name) == 1:
-            obj = self._bindings[binding_type].get(name[0])
-            if obj is None:
+            if name[0] not in self._bindings[binding_type]:
                 raise NameNotFoundException(name[0], binding_type)
-            return obj
+            return self._bindings[binding_type][name[0]]
         else:
             context = self._bindings[BindingType.named_context].get(name[0])
             if context is None:

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -585,6 +585,18 @@ class ConstantNamingContext(AbstractNamingContext):
         assert constant_type in (int, str, bool, float, Decimal)
         self.constant_type = constant_type
 
+    @classmethod
+    def _assert_valid_name(cls, name:str) -> Name:
+        """
+        Helper method that validates a name and returns its composite form.
+
+        :raises:
+            NamingException NamingException.Message.invalid_name: The supplied name is invalid (i.e. is not a valid string).
+        """
+        if not isinstance(name, str):
+            raise NamingException(NamingException.Message.invalid_name)
+        return tuple([name])
+
     @AbstractNamingContext.check_bounded
     def resolve(self, name: str) -> object:
         """
@@ -599,8 +611,7 @@ class ConstantNamingContext(AbstractNamingContext):
             NamingException NamingException.Message.invalid_name: when the name is invalid (None or length less than 1).
             NameNotFoundException NamingException.Message.name_not_found: if no binding was found for the given name.
         """
-        if not isinstance(name, str):
-            raise NamingException(NamingException.Message.invalid_name)
+        self._assert_valid_name(name)
         try:
             return self.constant_type(name)
         except ValueError:

--- a/camelot/core/naming.py
+++ b/camelot/core/naming.py
@@ -739,13 +739,14 @@ class InitialNamingContext(NamingContext, metaclass=Singleton):
         # resolution of subcontexts.
         self._name = tuple()
 
-        # Bind values and contexts for each supported 'constant' python type.
-        constants = self.bind_new_context('constants')
+        # Add immutable bindings for constants' values and contexts for each supported 'constant' python type.
+        constants = self.new_context()
+        self._add_binding('constants', constants, rebind=False, BindingType.named_context, immutable=True)
         for constant_type in (str, int, Decimal): # Do not support floats, as vFinance uses Decimals throughout
-            constants.bind_context(constant_type.__name__.lower(), ConstantNamingContext(constant_type))
-        constants.bind('None', None)
-        constants.bind('True', True)
-        constants.bind('False', False)
+            constants._add_binding(constant_type.__name__.lower(), ConstantNamingContext(constant_type), rebind=False, BindingType.named_context, immutable=True)
+        constants._add_binding('None', None, rebind=False, BindingType.named_object, immutable=True)
+        constants._add_binding('True', True, BindingType.named_object, immutable=True)
+        constants._add_binding('False', False, BindingType.named_object, immutable=True)
 
     def new_context(self) -> NamingContext:
         """

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -161,8 +161,15 @@ class AbstractNamingContextCaseMixin(object):
     context_name = None
     context_cls = None
 
-    # Name values that should throw an invalid_name NamingException.
-    invalid_names = [None, '', tuple(), ('',), (None,)]
+    # Name values that should throw an invalid_name NamingException with corresponding reason.
+    invalid_names = [
+        # value   reason
+        (None,    NamingException.Message.invalid_name_type),
+        ('',      NamingException.Message.invalid_atomic_name_length),
+        (tuple(), NamingException.Message.invalid_composite_name_length),
+        (('',),   NamingException.Message.invalid_atomic_name_length),
+        ((None,), NamingException.Message.invalid_composite_name_parts)
+    ]
     valid_names = ['test', ('test',), ('first', 'second')]
 
     def new_context(self):
@@ -179,10 +186,11 @@ class AbstractNamingContextCaseMixin(object):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.get_qual_name(invalid_name)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
         # Verify the qualified name resolution of a context concatenates its name prefix with the provid name:
         # So the qualified result should just be the composite form of the provided name.
@@ -204,10 +212,11 @@ class AbstractNamingContextCaseMixin(object):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.resolve(invalid_name)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
     # Some naming contexts implementation may not implement the complete AbstractNamingContext interface,
     # so assert a NotImplementedError by default so corresponding test cases verify this.
@@ -261,10 +270,11 @@ class NamingContextCaseMixin(AbstractNamingContextCaseMixin):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.bind(invalid_name, 2)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
         # Test the binding of an object to the context, which should return the fully qualified binding name,
         # and verify it can be looked back up on both the context (with the bound name),
@@ -311,10 +321,11 @@ class NamingContextCaseMixin(AbstractNamingContextCaseMixin):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.rebind(invalid_name, 2)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
         # Test rebinding without an existing binding, which should behave like the regular bind():
         name, obj = 'obj1', object()
@@ -398,10 +409,11 @@ class NamingContextCaseMixin(AbstractNamingContextCaseMixin):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.bind_context(invalid_name, subcontext)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
         # The passed object should be asserted to be an instance of NamingContext:
         for invalid_context in [None, '', object()]:
@@ -457,10 +469,11 @@ class NamingContextCaseMixin(AbstractNamingContextCaseMixin):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.rebind_context(invalid_name, subcontext)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
         # The passed object should be asserted to be an instance of NamingContext:
         for invalid_context in [None, '', object()]:
@@ -522,10 +535,11 @@ class NamingContextCaseMixin(AbstractNamingContextCaseMixin):
         name2, obj2 = ('subcontext', 'obj2'), object()
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.unbind(invalid_name)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
         # Unbinding should fail when no existing binding was found:
         with self.assertRaises(NameNotFoundException) as exc:
@@ -588,10 +602,11 @@ class NamingContextCaseMixin(AbstractNamingContextCaseMixin):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.unbind_context(invalid_name)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
         # Unbinding should fail when no existing binding was found:
         with self.assertRaises(NameNotFoundException) as exc:
@@ -643,10 +658,11 @@ class NamingContextCaseMixin(AbstractNamingContextCaseMixin):
             initial_naming_context.bind_context(self.context_name, self.context)
 
         # Verify invalid names throw the appropriate exception:
-        for invalid_name in self.invalid_names:
+        for invalid_name, reason in self.invalid_names:
             with self.assertRaises(NamingException) as exc:
                 self.context.resolve_context(invalid_name)
-            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name)
+            self.assertEqual(exc.exception.message, NamingException.Message.invalid_name, invalid_name)
+            self.assertEqual(exc.exception.reason, reason, invalid_name)
 
 class AbstractNamingContextCase(unittest.TestCase):
 
@@ -673,7 +689,15 @@ class ConstantNamingContextCaseMixin(AbstractNamingContextCaseMixin):
     constant_type = None
 
     # Constant naming context only allows string names, but allows the empty string:
-    invalid_names = [None, tuple(), (1,), (None,), ('test', ''), ('test', None), ('test', 'test')]
+    invalid_names = [
+        (None,             NamingException.Message.invalid_name_type),
+        (tuple(),          NamingException.Message.invalid_composite_name_length),
+        ((1,),             NamingException.Message.invalid_composite_name_parts),
+        ((None,),          NamingException.Message.invalid_composite_name_parts),
+        (('test', ''),     NamingException.Message.singular_name_expected),
+        (('test', None),   NamingException.Message.invalid_composite_name_parts),
+        (('test', 'test'), NamingException.Message.singular_name_expected),
+    ]
     valid_names = ['', 'x', '-1', '0', '1', 'True', '1.5', 'test']
 
     # Names may be valid arguments, but still fail the resolve (e.g. the conversion to the constant type).

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -14,6 +14,8 @@ from camelot.core.naming import (
 from camelot.core.profile import Profile, ProfileStore
 from camelot.core.qt import QtCore, py_to_variant, variant_to_py
 
+from decimal import Decimal
+
 memento_id_counter = 0
 
 class MementoCase(unittest.TestCase, ExampleModelMixinCase):
@@ -722,10 +724,10 @@ class IntegerNamingContextCase(AbstractNamingContextCase, ConstantNamingContextC
     incompatible_names = ['', 'x', 'True', '1.5', 'test']
     compatible_names = [('-1', -1), ('0', 0), ('2', 2)]
 
-class BooleanNamingContextCase(AbstractNamingContextCase, ConstantNamingContextCaseMixin):
+class DecimalNamingContextCase(AbstractNamingContextCase, ConstantNamingContextCaseMixin):
 
-    context_name = ('bool',)
-    constant_type = bool
+    context_name = ('decimal',)
+    constant_type = Decimal
 
-    incompatible_names = ['', 'x', '-1', '0', '1', 'True', '1.5', 'test']
-    compatible_names = [('True', True), ('False', False), ('2', 2)]
+    incompatible_names = ['', 'x', 'True', 'test']
+    compatible_names = [('-1', Decimal(-1)), ('0', Decimal(0)), ('2', Decimal(2)), ('1.5', Decimal(1.5))]

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -798,10 +798,10 @@ class InitialNamingContextCase(NamingContextCase):
 
         # Verify that the constant naming contexts are available by default on the initial context:
         # * Boolean values
-        self.assertEqual(self.context.resolve(('constants', 'True')), True)
-        self.assertEqual(self.context.resolve(('constants', 'False')), False)
+        self.assertEqual(self.context.resolve(('constants', 'true')), True)
+        self.assertEqual(self.context.resolve(('constants', 'false')), False)
         # * None value
-        self.assertEqual(self.context.resolve(('constants', 'None')), None)
+        self.assertEqual(self.context.resolve(('constants', 'null')), None)
         # * Int values
         self.assertEqual(self.context.resolve(('constants', 'int', '-1')), -1)
         self.assertEqual(self.context.resolve(('constants', 'int', '0')), 0)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -162,7 +162,7 @@ class AbstractNamingContextCaseMixin(object):
     context_cls = None
 
     # Name values that should throw an invalid_name NamingException.
-    invalid_names = [None, '', tuple(), ('',), (None,), ('test', ''), ('test', None)]
+    invalid_names = [None, '', tuple(), ('',), (None,)]
     valid_names = ['test', ('test',), ('first', 'second')]
 
     def new_context(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -816,3 +816,15 @@ class InitialNamingContextCase(NamingContextCase):
         self.assertEqual(self.context.resolve(('constants', 'decimal', '0')), Decimal(0))
         self.assertEqual(self.context.resolve(('constants', 'decimal', '0.0')), Decimal(0.0))
         self.assertEqual(self.context.resolve(('constants', 'decimal', '2')), Decimal(2))
+
+        # Verify that those constants contexts are immutabe on the initial naming context:
+        with self.assertRaises(ImmutableBindingException):
+            self.context.rebind_context('constants', NamingContext())
+        with self.assertRaises(ImmutableBindingException):
+            self.context.unbind_context('constants')
+
+        constants = self.context.resolve_context('constants')
+        with self.assertRaises(ImmutableBindingException):
+            constants.rebind_context('str', NamingContext())
+        with self.assertRaises(ImmutableBindingException):
+            constants.unbind_context('str')


### PR DESCRIPTION
* Split up and fixed definition of atomic and composite names used with naming contexts.
* Handle resolving of bound None objects
* Cleaned up constants context registration on initial naming context
* Added immutable constant context for Decimal.
* Added support for immutable bindings and corresponding exception safeguards
* Expanded invalid name NamingExceptions with more detailed message including the reason for the invalidity