### PR TITLE
VFIN-1997: Simplify gui_run logic + CrudItemModel fixes

### DIFF
--- a/camelot/admin/action/base.py
+++ b/camelot/admin/action/base.py
@@ -280,24 +280,27 @@ return immediately and the :meth:`model_run` will not be blocked.
 
     blocking = True
     cancelable = True
-            
-    def gui_run( self, gui_context ):
+
+    @classmethod
+    def gui_run( cls, gui_context, serialized_step=b'' ):
         """This method is called in the *GUI thread* upon execution of the
         action step.  The return value of this method is the result of the
         :keyword:`yield` statement in the *model thread*.
         
-        The default behavior of this method is to call the model_run generator
-        in the *model thread* until it is finished.
+        The default behavior of this method is to call the qml_action_step
+        function.
         
         :param gui_context:  An object of type 
             :class:`camelot.admin.action.GuiContext`, which is the context 
             of this action available in the *GUI thread*.  What is in the 
             context depends on how the action was called.
+        :param serialized_step: The serialized action step.
             
         this method will raise a :class:`camelot.core.exception.CancelRequest`
         exception, if the user canceled the operation.
         """
-        raise NotImplementedError()
+        from camelot.view.qml_view import qml_action_step
+        return qml_action_step(gui_context, cls.__name__, serialized_step)
 
     def model_run( self, model_context, mode ):
         raise Exception('This should not happen')

--- a/camelot/admin/action/list_action.py
+++ b/camelot/admin/action/list_action.py
@@ -403,6 +403,7 @@ class DeleteSelection( EditAction ):
     def handle_object( self, model_context, obj ):
         from camelot.view import action_steps
         model_context.proxy.remove(obj)
+        # use group -> 2 loops (yield + delete)
         yield action_steps.DeleteObjects((obj,))
         model_context.admin.delete(obj)
 

--- a/camelot/view/action_runner.py
+++ b/camelot/view/action_runner.py
@@ -181,15 +181,10 @@ class ActionRunner( QtCore.QEventLoop ):
 
     @QtCore.qt_slot(str, bytes)
     def non_blocking_serializable_action_step(self, step_type, serialized_step):
-        from camelot.view.qml_view import is_cpp_action_step, qml_action_step
-
         cls = MetaActionStep.action_steps[step_type]
         try:
             self._was_canceled(self._gui_context)
-            if is_cpp_action_step(self._gui_context, step_type):
-                qml_action_step(self._gui_context, step_type, serialized_step)
-            else:
-                cls.gui_run(self._gui_context, serialized_step)
+            cls.gui_run(self._gui_context, serialized_step)
         except CancelRequest:
             LOGGER.debug( 'non blocking action step requests cancel, set flag' )
             self._non_blocking_cancel_request = True
@@ -235,18 +230,13 @@ class ActionRunner( QtCore.QEventLoop ):
         :param yielded: the object that was yielded by the generator in the
             *model thread*
         """
-        from camelot.view.qml_view import is_cpp_action_step, qml_action_step
-
         if isinstance(yielded, (ActionStep, tuple)):
             try:
                 self._was_canceled(self._gui_context)
                 if isinstance(yielded, tuple):
                     step_type, serialized_step = yielded
                     cls = MetaActionStep.action_steps[step_type]
-                    if is_cpp_action_step(self._gui_context, step_type):
-                        to_send = qml_action_step(self._gui_context, step_type, serialized_step)
-                    else:
-                        to_send = cls.gui_run(self._gui_context, serialized_step)
+                    to_send = cls.gui_run(self._gui_context, serialized_step)
                     to_send = cls.deserialize_result(self._gui_context, to_send)
                 else:
                     to_send = yielded.gui_run(self._gui_context)

--- a/camelot/view/action_steps/crud.py
+++ b/camelot/view/action_steps/crud.py
@@ -204,8 +204,6 @@ class Created(ActionStep, UpdateMixin):
         self.changed_ranges = changed_ranges
         
     def gui_run(self, item_model):
-        if is_deleted(item_model):
-            return
         # appending new items to the model will increase the rowcount, so
         # there is no need to set the rowcount explicitly
         self.update_item_model(item_model) 

--- a/camelot/view/action_steps/gui.py
+++ b/camelot/view/action_steps/gui.py
@@ -62,6 +62,7 @@ class Refresh( ActionStep, DataclassSerializable ):
     def gui_run(self, gui_context, serialized_step):
         if gui_context.workspace:
             gui_context.workspace.refresh()
+        qml_action_step(gui_context, 'Refresh')
 
 class ItemSelectionDialog(StandaloneWizardPage):
 

--- a/camelot/view/action_steps/gui.py
+++ b/camelot/view/action_steps/gui.py
@@ -46,6 +46,7 @@ from camelot.core.utils import ugettext_lazy, ugettext_lazy as _
 from camelot.view.controls import editors
 from camelot.view.controls.standalone_wizard_page import StandaloneWizardPage
 from camelot.view.action_runner import hide_progress_dialog
+from camelot.view.qml_view import qml_action_step
 from ...core.qt import QtCore, QtWidgets, is_deleted
 from ...core.serializable import DataclassSerializable
 from ..art import FontIcon
@@ -170,6 +171,8 @@ class CloseView(ActionStep, DataclassSerializable):
             view = gui_context.view
             if view is not None and not is_deleted(view):
                 view.close_view(step["accept"])
+        else:
+            qml_action_step(gui_context, 'CloseView', serialized_step)
 
 
 @dataclass

--- a/camelot/view/action_steps/item_view.py
+++ b/camelot/view/action_steps/item_view.py
@@ -52,7 +52,7 @@ from ..workspace import show_top_level
 from ..proxy.collection_proxy import (
     CollectionProxy, rowcount_name, rowdata_name, setcolumns_name, RowModelContext
 )
-from ..qml_view import qml_action_step
+from ..qml_view import qml_action_step, is_cpp_gui_context
 
 LOGGER = logging.getLogger(__name__)
 
@@ -310,7 +310,9 @@ class ToFirstRow(ActionStep, DataclassSerializable):
 
     @classmethod
     def gui_run(cls, gui_context, serialized_step):
-        if gui_context.item_view is not None:
+        if is_cpp_gui_context(gui_context):
+            qml_action_step(gui_context, 'ToFirstRow')
+        else:
             gui_context.item_view.selectRow( 0 )
 
 
@@ -320,7 +322,9 @@ class ToLastRow(ActionStep, DataclassSerializable):
 
     @classmethod
     def gui_run(cls, gui_context, serialized_step):
-        if gui_context.item_view is not None:
+        if is_cpp_gui_context(gui_context):
+            qml_action_step(gui_context, 'ToLastRow')
+        else:
             item_view = gui_context.item_view
             item_view.selectRow( item_view.model().rowCount() - 1 )
 
@@ -331,7 +335,9 @@ class ClearSelection(ActionStep, DataclassSerializable):
 
     @classmethod
     def gui_run(cls, gui_context, serialized_step):
-        if gui_context.item_view is not None:
+        if is_cpp_gui_context(gui_context):
+            qml_action_step(gui_context, 'ClearSelection', serialized_step)
+        else:
             gui_context.item_view.clearSelection()
 
 
@@ -350,6 +356,9 @@ class RefreshItemView(ActionStep, DataclassSerializable):
 
     @classmethod
     def gui_run(cls, gui_context, serialized_step):
-        model = gui_context.get_item_model()
-        if model is not None:
-            model.refresh()
+        if is_cpp_gui_context(gui_context):
+            qml_action_step(gui_context, 'RefreshItemView', serialized_step)
+        else:
+            model = gui_context.get_item_model()
+            if model is not None:
+                model.refresh()

--- a/camelot/view/qml_view.py
+++ b/camelot/view/qml_view.py
@@ -1,7 +1,6 @@
 import logging
 import itertools
 import json
-import inspect
 
 from camelot.core.qt import QtWidgets, QtQuick, QtCore, QtQml, is_deleted
 from camelot.core.exception import UserException
@@ -112,6 +111,8 @@ def is_cpp_gui_context(gui_context):
     """
     Check if a GUI context's name was created in C++. This is the case when the name starts with 'cpp_gui_context'.
     """
+    if gui_context is None:
+        return False
     if gui_context.gui_context_name is None:
         return False
     return is_cpp_gui_context_name(gui_context.gui_context_name)

--- a/camelot/view/qml_view.py
+++ b/camelot/view/qml_view.py
@@ -207,33 +207,6 @@ class QmlActionDispatch(QtCore.QObject):
 qml_action_dispatch = QmlActionDispatch()
 
 
-def is_cpp_action_step(gui_context, action_step):
-    if inspect.isclass(action_step):
-        action_step = action_step.__name__
-
-    always_cpp = [
-        'NavigationPanel',
-        'SetThemeColors',
-        'MainMenu',
-        'InstallTranslator',
-        'RemoveTranslator',
-    ]
-    if action_step in always_cpp:
-        return True
-
-    if not is_cpp_gui_context(gui_context):
-        return False
-
-    return action_step in [
-        'ToFirstRow',
-        'ToLastRow',
-        'ClearSelection',
-        'SetSelection',
-        'RefreshItemView',
-        'CloseView',
-    ]
-
-
 # FIXME: rename to cpp_action_step?
 def qml_action_step(gui_context, name, step=QtCore.QByteArray(), props={}, model=None):
     """


### PR DESCRIPTION
De Refresh en CreateUpdateDelete action steps werken nu ook met het CrudItemModel.