### PR TITLE
VFIN-2613 Fixed related status objects deletability.

### DIFF
--- a/camelot/admin/action/list_action.py
+++ b/camelot/admin/action/list_action.py
@@ -207,6 +207,13 @@ class DeleteSelection( EditAction ):
         admin = model_context.admin
         if model_context.selection_count <= 0:
             return
+
+        # Check if all objects to removed are permitted to do so,
+        # and raised otherwise.
+        objects_to_remove = list( model_context.get_selection() )
+        for obj in objects_to_remove:
+            admin.deletable_or_raise(obj)
+
         answer = yield action_steps.MessageBox(
             title = ugettext('Remove %s %s ?')%( model_context.selection_count, ugettext('rows') ),
             icon = Icon('question'), 
@@ -216,7 +223,7 @@ class DeleteSelection( EditAction ):
         )
         if answer != QtWidgets.QMessageBox.StandardButton.Yes:
             return
-        objects_to_remove = list( model_context.get_selection() )
+
         #
         # it might be impossible to determine the depending objects once
         # the object has been removed from the collection

--- a/camelot/admin/entity_admin.py
+++ b/camelot/admin/entity_admin.py
@@ -532,6 +532,10 @@ and used as a custom action.
         # new and deleted instances cannot be deleted
         #
         if session:
+
+            # First check the instance is allowed to be deleted and raise otherwise.
+            self.deletable_or_raise(entity_instance)
+
             if entity_instance in session.new:
                 session.expunge(entity_instance)
             elif entity_instance not in session.deleted:

--- a/camelot/admin/object_admin.py
+++ b/camelot/admin/object_admin.py
@@ -1136,6 +1136,14 @@ be specified using the verbose_name attribute.
         """
         return True
 
+    def deletable_or_raise(self, obj):
+        """
+        Check the given instance is allowed to be deleted within the context of this
+        admin or raise a UserException otherwise.
+        """
+        if not self.is_obj_deletable(obj):
+            raise UserException(_('{} is not permitted to be deleted'), obj)
+
     def get_subsystem_object(self, obj):
         """Return the given object's applicable subsystem object."""
         return obj

--- a/camelot/admin/object_admin.py
+++ b/camelot/admin/object_admin.py
@@ -41,6 +41,7 @@ from camelot.admin.action import field_action, list_filter
 from camelot.admin.action.list_action import OpenFormView
 from camelot.admin.action.form_action import CloseForm
 from camelot.admin.not_editable_admin import ReadOnlyAdminDecorator
+from camelot.core.exception import UserException
 from camelot.core.naming import initial_naming_context
 from camelot.core.orm import Entity, EntityMeta
 from camelot.view.utils import to_string
@@ -1070,6 +1071,7 @@ be specified using the verbose_name attribute.
 
     def delete(self, entity_instance):
         """Delete an entity instance"""
+        self.deletable_or_raise(entity_instance)
         del entity_instance
 
     def flush(self, entity_instance):
@@ -1115,7 +1117,23 @@ be specified using the verbose_name attribute.
         return new_entity_instance
 
     def is_editable(self):
-        """Default implementation always returns True"""
+        """
+        Return whether this admin globally allows instances being edited.
+        """
+        return True
+
+    def is_obj_editable(self, obj):
+        """
+        Return whether the given instance may be edited within the context of this admin.
+        Defaults to True if this admin is globally editable, False otherwise.
+        """
+        return self.is_editable()
+
+    def is_obj_deletable(self, obj):
+        """
+        Return whether the given instance is allowed to be deleted within the context of this admin.
+        Defaults to True.
+        """
         return True
 
     def get_subsystem_object(self, obj):


### PR DESCRIPTION
* Expanded admins to support configuring authorization for editing and deleting objects on a per instance basis.
* Fixed DeleteSelection action to first check selected objects are allowed to be deleted (and raise if not) before removing the objects from the proxy (or the database).